### PR TITLE
Fix testing artifact

### DIFF
--- a/test/lesson1_test.exs
+++ b/test/lesson1_test.exs
@@ -3,6 +3,10 @@ defmodule Lesson1Test do
   use ExUnit.Case, async: true
 
   test "run it" do
+      on_exit fn ->
+        # Delete an artifact created by evaluating all code in the tutorial
+        File.rm('births1880.csv')
+      end
     tutorial_text = File.read!("tutorial/lesson1.md")
     all_code_in_tutorial =  Enum.join List.flatten Regex.scan(~r/```elixir(.*?)```/s, tutorial_text, capture: :all_but_first)
     Code.eval_string(all_code_in_tutorial)


### PR DESCRIPTION
The "run it" test in Lesson1Test was generating `births1880.csv` in the current working directory. This doesn't stop that, but it does remove it after the test runs, whether the test fails or not.
